### PR TITLE
Explicitly cast return value to `int32_t`.

### DIFF
--- a/jump/jump.cpp
+++ b/jump/jump.cpp
@@ -13,5 +13,5 @@ JumpConsistentHash(uint64_t key, int32_t num_buckets)
         j = (b + 1) * (double(1LL << 31) / double((key >> 33) + 1));
     }
 
-    return b;
+    return (int32_t)b;
 }


### PR DESCRIPTION
Fixes #5.