### PR TITLE
Remove race workaround for running tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,7 @@ all:
 build:
 	python setup.py build
 
-# A race condition occurs where the file hasn't been completely copied before
-# the testrunner tries to import `_jump`. To prevent this we copy the file
-# manually before running the tests.
-%.so:
-	cp $(shell find build -name "_jump*.so") "$(CURDIR)/$<"
-
-
-test: build %.so
+test:
 	python setup.py test
 
 clean:


### PR DESCRIPTION
Presumably this was fixed in some version of setuptools.